### PR TITLE
Uptook latest nukleus.spec with window credit and padding.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <nukleus.version>0.11</nukleus.version>
     <nukleus.plugin.version>0.13</nukleus.plugin.version>
-    <nukleus.spec.version>0.10</nukleus.spec.version>
+    <nukleus.spec.version>0.12</nukleus.spec.version>
     <nukleus.http.spec.version>0.38</nukleus.http.spec.version>
 
     <jacoco.coverage.ratio>1.00</jacoco.coverage.ratio>

--- a/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
@@ -187,9 +187,9 @@ public final class LoggableStream implements AutoCloseable
         final WindowFW window)
     {
         final long streamId = window.streamId();
-        final int update = window.update();
-        final int frames = window.frames();
+        final int credit = window.credit();
+        final int padding = window.padding();
 
-        out.printf(format(throttleFormat, streamId, format("WINDOW [%d] [%d]", update, frames)));
+        out.printf(format(throttleFormat, streamId, format("WINDOW [%d] [%d]", credit, padding)));
     }
 }


### PR DESCRIPTION
This is required for command-log to be able to analyze shm files produced by the latest released nuklei.