### PR TITLE
Expose routes via command log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
     <checkstyle.suppressions.location>src/conf/checkstyle/suppressions.xml</checkstyle.suppressions.location>
 
     <nukleus.version>0.13</nukleus.version>
-    <nukleus.plugin.version>0.13</nukleus.plugin.version>
-    <nukleus.spec.version>0.13</nukleus.spec.version>
+    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.spec.version>develop-SNAPSHOT</nukleus.spec.version>
     <nukleus.http.spec.version>0.43</nukleus.http.spec.version>
 
     <jacoco.coverage.ratio>1.00</jacoco.coverage.ratio>
@@ -84,7 +84,7 @@
         <artifactId>nukleus-maven-plugin</artifactId>
         <version>${nukleus.plugin.version}</version>
         <configuration>
-          <scopeNames>core::stream http::stream</scopeNames>
+          <scopeNames>core http::stream</scopeNames>
           <packageName>org.reaktivity.command.log.internal.types</packageName>
         </configuration>
         <executions>

--- a/src/main/java/org/reaktivity/command/log/internal/ConfigurationUtil.java
+++ b/src/main/java/org/reaktivity/command/log/internal/ConfigurationUtil.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.command.log.internal;
+
+import java.util.function.BiFunction;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+public class ConfigurationUtil
+{
+    private final BiFunction<String, String, String> getProperty;
+    private final BiFunction<String, String, String> getPropertyDefault;
+
+    public ConfigurationUtil()
+    {
+        this.getProperty = System::getProperty;
+        this.getPropertyDefault = (p, d) -> d;
+    }
+
+    protected final int getInteger(String key, int defaultValue)
+    {
+        String value = getProperty(key, (String) null);
+        if (value == null)
+        {
+            return defaultValue;
+        }
+        return Integer.decode(value);
+    }
+
+    protected final boolean getBoolean(String key, boolean defaultValue)
+    {
+        String value = getProperty(key, (String) null);
+        if (value == null)
+        {
+            return defaultValue;
+        }
+        return Boolean.valueOf(value);
+    }
+
+    protected final String getProperty(String key, Supplier<String> defaultValue)
+    {
+        String value = getProperty(key, (String) null);
+        if (value == null)
+        {
+            return defaultValue.get();
+        }
+        return value;
+    }
+
+    protected final int getInteger(String key, IntSupplier defaultValue)
+    {
+        String value = getProperty(key, (String) null);
+        if (value == null)
+        {
+            return defaultValue.getAsInt();
+        }
+        return Integer.decode(value);
+    }
+
+    protected final boolean getBoolean(String key, BooleanSupplier defaultValue)
+    {
+        String value = getProperty(key, (String) null);
+        if (value == null)
+        {
+            return defaultValue.getAsBoolean();
+        }
+        return Boolean.valueOf(value);
+    }
+
+    protected String getProperty(String key, String defaultValue)
+    {
+        return getProperty.apply(key, getPropertyDefault.apply(key, defaultValue));
+    }
+}

--- a/src/main/java/org/reaktivity/command/log/internal/LogCommand.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LogCommand.java
@@ -37,7 +37,7 @@ public final class LogCommand
         options.addOption(builder("t").hasArg()
                                       .required(false)
                                       .longOpt("type")
-                                      .desc("streams* | streams-nowait | counters | queues | routes | routing")
+                                      .desc("streams* | streams-nowait | counters | queues | routes")
                                       .build());
         options.addOption(builder("d").longOpt("directory").hasArg().desc("configuration directory").build());
         options.addOption(builder("v").longOpt("verbose").desc("verbose output").build());
@@ -72,9 +72,9 @@ public final class LogCommand
             {
                 new LogQueueDepthCommand(config, System.out::printf, verbose).invoke();
             }
-            else if ("routes".equals(type) || "routing".equals(type))
+            else if ("routes".equals(type))
             {
-                new LogRoutesCommand(config, System.out::printf, verbose, "routing".equals(type)).invoke();
+                new LogRoutesCommand(config, System.out::printf, verbose).invoke();
             }
         }
     }

--- a/src/main/java/org/reaktivity/command/log/internal/LogCommand.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LogCommand.java
@@ -34,8 +34,11 @@ public final class LogCommand
 
         Options options = new Options();
         options.addOption(builder("h").longOpt("help").desc("print this message").build());
-        options.addOption(builder("t").hasArg().required(false)
-                                      .longOpt("type").desc("streams* | streams-nowait | counters | queues").build());
+        options.addOption(builder("t").hasArg()
+                                      .required(false)
+                                      .longOpt("type")
+                                      .desc("streams* | streams-nowait | counters | queues | routes | routing")
+                                      .build());
         options.addOption(builder("d").longOpt("directory").hasArg().desc("configuration directory").build());
         options.addOption(builder("v").longOpt("verbose").desc("verbose output").build());
 
@@ -68,6 +71,10 @@ public final class LogCommand
             else if ("queues".equals(type))
             {
                 new LogQueueDepthCommand(config, System.out::printf, verbose).invoke();
+            }
+            else if ("routes".equals(type) || "routing".equals(type))
+            {
+                new LogRoutesCommand(config, System.out::printf, verbose, "routing".equals(type)).invoke();
             }
         }
     }

--- a/src/main/java/org/reaktivity/command/log/internal/LogRoutesCommand.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LogRoutesCommand.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.command.log.internal;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.agrona.LangUtil;
+import org.agrona.concurrent.BackoffIdleStrategy;
+import org.agrona.concurrent.IdleStrategy;
+import org.reaktivity.command.log.internal.layouts.RoutesLayout;
+import org.reaktivity.nukleus.Configuration;
+
+public class LogRoutesCommand
+{
+
+    public static final String ROUTES_BUFFER_CAPACITY_PROPERTY_NAME = "reaktor.routes.buffer.capacity";
+    public static final int ROUTES_BUFFER_CAPACITY_DEFAULT = 1024 * 1024;
+
+    private static final long MAX_PARK_NS = MILLISECONDS.toNanos(100L);
+    private static final long MIN_PARK_NS = MILLISECONDS.toNanos(1L);
+    private static final int MAX_YIELDS = 300;
+    private static final int MAX_SPINS = 200;
+
+    private final Path directory;
+    private final boolean verbose;
+    private final int routesCapacity;
+    private final boolean continuous;
+    private final Logger out;
+    private final ConfigurationUtil configUtil = new ConfigurationUtil();
+    private final IdleStrategy idleStrategy = new BackoffIdleStrategy(MAX_SPINS, MAX_YIELDS, MIN_PARK_NS, MAX_PARK_NS);
+
+
+    LogRoutesCommand(
+        Configuration config,
+        Logger out,
+        boolean verbose,
+        boolean continuous)
+    {
+        this.directory = config.directory();
+        this.verbose = verbose;
+        this.routesCapacity = configUtil.getInteger(ROUTES_BUFFER_CAPACITY_PROPERTY_NAME, ROUTES_BUFFER_CAPACITY_DEFAULT);
+        this.out = out;
+        this.continuous = continuous;
+    }
+
+    private boolean isRoutesFile(
+        Path path)
+    {
+        return path.getNameCount() - directory.getNameCount() == 2 &&
+               "routes".equals(path.getName(path.getNameCount() - 1).toString()) &&
+               Files.isRegularFile(path);
+    }
+
+    private LoggableRoutes newLoggable(
+        Path path)
+    {
+
+        RoutesLayout layout = new RoutesLayout.Builder()
+                .routesPath(path)
+                .routesBufferCapacity(routesCapacity)
+                .build();
+
+        String nukleusName = path.getName(path.getNameCount() - 2).toString();
+
+        return new LoggableRoutes(layout, nukleusName, out, idleStrategy);
+    }
+
+    private void onDiscovered(
+        Path path)
+    {
+        if (verbose)
+        {
+            out.printf("Discovered: %s\n", path);
+        }
+    }
+
+    void invoke()
+    {
+        try (Stream<Path> files = Files.walk(directory, 2))
+        {
+            LoggableRoutes[] loggables = files.filter(this::isRoutesFile)
+                 .peek(this::onDiscovered)
+                 .map(this::newLoggable)
+                 .collect(toList())
+                 .toArray(new LoggableRoutes[0]);
+
+            final int exitWorkCount = continuous ? -1 : 0;
+            int successCount;
+            do
+            {
+                successCount = 0;
+
+                for (int i=0; i < loggables.length; i++)
+                {
+                    successCount += loggables[i].process();
+                }
+
+                idleStrategy.idle(successCount);
+
+            } while (successCount != exitWorkCount);
+        }
+        catch (IOException ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+    }
+
+}

--- a/src/main/java/org/reaktivity/command/log/internal/LoggableRoutes.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LoggableRoutes.java
@@ -106,7 +106,7 @@ public final class LoggableRoutes implements AutoCloseable
             if (!loggedRoutes.contains(correlationId))
             {
                 workCnt.incrementAndGet();
-                out.printf(format("%-15s %10s %20s [0x%016X] %20s [0x%016X] [0x%016X]\n",
+                out.printf(format("%15s   %-10s %-20s [0x%016X] %-20s [0x%016X] [0x%016X]\n",
                                 format("%s#%d", nukleusName, correlationId),
                                 role,
                                 source,

--- a/src/main/java/org/reaktivity/command/log/internal/LoggableRoutes.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LoggableRoutes.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.command.log.internal;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.LongHashSet;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.reaktivity.command.log.internal.layouts.RoutesLayout;
+import org.reaktivity.command.log.internal.types.OctetsFW;
+import org.reaktivity.command.log.internal.types.control.RouteFW;
+import org.reaktivity.command.log.internal.types.state.RouteTableFW;
+
+public final class LoggableRoutes implements AutoCloseable
+{
+    private final RoutesLayout layout;
+    private final MutableDirectBuffer routesBuffer;
+    private final String routesFormat;
+    private final Logger out;
+    private final IdleStrategy idleStrategy;
+    private final RouteTableFW routeTableRO;
+    private final byte[] copyBuf;
+    private final int capacity;
+    private final UnsafeBuffer copyBufFW;
+    private final RouteFW routeRO;
+    private final LongHashSet loggedRoutes;
+
+    LoggableRoutes(
+        RoutesLayout layout,
+        String nukleusName,
+        Logger logger,
+        IdleStrategy idleStrategy)
+    {
+        this.layout = layout;
+        this.routesBuffer = layout.routesBuffer();
+        this.routesFormat = String.format("[%s]\t%%s\n", nukleusName);
+        this.out = logger;
+        this.idleStrategy = idleStrategy;
+        this.routeTableRO = new RouteTableFW();
+        this.capacity = layout.capacity();
+        this.copyBuf = new byte[capacity];
+        this.copyBufFW = new UnsafeBuffer(copyBuf);
+        this.routeRO = new RouteFW();
+        this.loggedRoutes = new LongHashSet(-1);
+    }
+
+    int process()
+    {
+        RouteTableFW routeTable = routeTableRO.wrap(routesBuffer, 0, capacity);
+        final int beforeAcquires = routeTableRO.writeLockAcquires();
+        if (beforeAcquires == routeTableRO.writeLockReleases())
+        {
+            routesBuffer.getBytes(0, copyBuf);
+            copyBufFW.wrap(copyBuf);
+            routeTable = routeTableRO.wrap(copyBufFW, 0, capacity);
+            final int afterCopyAcquires = routeTable.writeLockAcquires();
+            if (beforeAcquires == afterCopyAcquires)
+            {
+                return logRoutes(routeTable, new LongHashSet(-1), new AtomicInteger(0));
+            }
+        }
+        idleStrategy.idle();
+        return process();
+    }
+
+    private int logRoutes(
+        RouteTableFW routeTable,
+        LongHashSet thisIterationRoutes,
+        AtomicInteger workCnt)
+    {
+        routeTable.routeEntries().forEach(e ->
+        {
+            final OctetsFW routeOctets = e.route();
+            final DirectBuffer buffer = routeOctets.buffer();
+            final int offset = routeOctets.offset();
+            final int routeSize = (int) e.routeSize();
+            RouteFW route = routeRO.wrap(buffer, offset, routeSize);
+
+            final long correlationId = route.correlationId();
+            final String role = route.role().toString();
+            final String source = route.source().asString();
+            final long sourceRef = route.sourceRef();
+            final String target = route.target().asString();
+            final long targetRef = route.targetRef();
+            final long authorization = route.authorization();
+//            final OctetsFW extension = route.extension(); TODO special logging for extension
+            thisIterationRoutes.add(correlationId);
+
+            if (!loggedRoutes.contains(correlationId))
+            {
+                workCnt.incrementAndGet();
+                out.printf(routesFormat,
+                        String.format("%d, %s, %s, %d, %s, %d, %d, %s",
+                                correlationId,
+                                role,
+                                source,
+                                sourceRef,
+                                target,
+                                targetRef,
+                                authorization));
+                loggedRoutes.add(correlationId);
+                workCnt.incrementAndGet();
+            }
+        });
+
+        LongHashSet removedRoutes = loggedRoutes.difference(thisIterationRoutes);
+        if (removedRoutes != null)
+        {
+            removedRoutes.stream().forEach(r ->
+            {
+                out.printf(routesFormat, String.format("Unrouted %s", r));
+                loggedRoutes.remove(r);
+            });
+        }
+        return workCnt.get();
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        layout.close();
+    }
+
+}

--- a/src/main/java/org/reaktivity/command/log/internal/layouts/RoutesLayout.java
+++ b/src/main/java/org/reaktivity/command/log/internal/layouts/RoutesLayout.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.command.log.internal.layouts;
+
+import static org.agrona.IoUtil.mapExistingFile;
+import static org.agrona.IoUtil.unmap;
+
+import java.io.File;
+import java.nio.MappedByteBuffer;
+import java.nio.file.Path;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class RoutesLayout extends Layout
+{
+
+    private final UnsafeBuffer routesBuffer;
+    private final int routesBufferCapacity;
+
+    private RoutesLayout(
+            UnsafeBuffer routesBuffer,
+        int routesBufferCapacity)
+    {
+        this.routesBuffer = routesBuffer;
+        this.routesBufferCapacity = routesBufferCapacity;
+    }
+
+    @Override
+    public void close()
+    {
+        unmap(routesBuffer().byteBuffer());
+    }
+
+    public MutableDirectBuffer routesBuffer()
+    {
+        return routesBuffer;
+    }
+
+    public int capacity()
+    {
+        return routesBufferCapacity;
+    }
+
+    public static final class Builder extends Layout.Builder<RoutesLayout>
+    {
+
+        private Path path;
+        private int routesBufferCapacity;
+
+        public Builder routesPath(Path path)
+        {
+            this.path = path;
+            return this;
+        }
+
+        public Builder routesBufferCapacity(
+            int routesBufferCapacity)
+        {
+            this.routesBufferCapacity = routesBufferCapacity;
+            return this;
+        }
+
+        @Override
+        public RoutesLayout build()
+        {
+            final File routes = path.toFile();
+
+            final MappedByteBuffer mappedRoutes = mapExistingFile(routes, "routes", 0, routesBufferCapacity);
+
+            final UnsafeBuffer mutableRoutesBuffer = new UnsafeBuffer(mappedRoutes);
+
+            return new RoutesLayout(mutableRoutesBuffer, routesBufferCapacity);
+        }
+
+    }
+}


### PR DESCRIPTION
Sample output
```
          sse#0   SERVER     http2                [0x0000000000000002] kafka-sse            [0x8000000000000002] [0x0000000000000000]
    kafka-sse#0   PROXY      sse                  [0x8000000000000002] kafka                [0x0000000000000001] [0x0000000000000000]
        http2#0   SERVER     tls                  [0x0000000000000002] sse                  [0x0000000000000002] [0x0000000000000000]
        http2#1   SERVER     tls                  [0x0000000000000002] http                 [0x0000000000000001] [0x0000000000000000]
          tls#0   SERVER     tcp                  [0x0000000000000002] http2                [0x0000000000000002] [0x0000000000000000]
          tls#1   CLIENT     http                 [0x0000000000000003] tcp                  [0x0000000000000003] [0x0000000000000000]
          tcp#0   CLIENT     kafka                [0x0000000000000001] kafka                [0x0000000000002384] [0x0000000000000000]
          tcp#1   SERVER     0.0.0.0              [0x00000000000001BB] tls                  [0x0000000000000002] [0x0000000000000000]
          tcp#2   CLIENT     tls                  [0x0000000000000003] static-http-server   [0x00000000000001BB] [0x0000000000000000]
         http#0   CLIENT     http2                [0x0000000000000001] tls                  [0x0000000000000003] [0x0000000000000000]
        kafka#0   CLIENT     kafka-sse            [0x0000000000000001] tcp                  [0x0000000000000001] [0x0000000000000000]

```