### PR TITLE
 Fixed printing verbose from Http source to high level target on begin frame

### DIFF
--- a/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
@@ -29,6 +29,9 @@ import org.reaktivity.command.log.internal.types.stream.HttpBeginExFW;
 import org.reaktivity.command.log.internal.types.stream.ResetFW;
 import org.reaktivity.command.log.internal.types.stream.WindowFW;
 
+import java.util.function.LongPredicate;
+import java.util.function.Predicate;
+
 public final class LoggableStream implements AutoCloseable
 {
     private final BeginFW beginRO = new BeginFW();
@@ -43,6 +46,7 @@ public final class LoggableStream implements AutoCloseable
 
     private final String streamFormat;
     private final String throttleFormat;
+    private final String targetName;
     private final StreamsLayout layout;
     private final RingBufferSpy streamsBuffer;
     private final RingBufferSpy throttleBuffer;
@@ -62,6 +66,7 @@ public final class LoggableStream implements AutoCloseable
         this.layout = layout;
         this.streamsBuffer = layout.streamsBuffer();
         this.throttleBuffer = layout.throttleBuffer();
+        this.targetName = receiver;
         this.out = logger;
         this.verbose = verbose;
     }
@@ -121,13 +126,24 @@ public final class LoggableStream implements AutoCloseable
 
         if (verbose && sourceName.startsWith("http"))
         {
-            final long ref = (sourceRef != 0) ? sourceRef : correlationId;
-            if(!((ref % 2 == 0) && sourceName.equals("http")) && !((ref % 2 != 0) && sourceName.equals("http2")))
-            {
-                    HttpBeginExFW httpBeginEx = httpBeginExRO.wrap(extension.buffer(), extension.offset(), extension.limit());
-                    httpBeginEx.headers()
-                            .forEach(h -> out.printf("%s: %s\n", h.name().asString(), h.value().asString()));
+            final boolean initial = (sourceRef != 0);
+            final long typedRef = (sourceRef != 0) ? sourceRef : correlationId;
+            final Predicate<String> isHttp = n -> n.startsWith("http");
+            final LongPredicate isClient = r -> r > 0L && (r & 0x01L) != 0x00L;
+            final LongPredicate isServer = r -> r > 0L && (r & 0x01L) == 0x00L;
+            final LongPredicate isProxy = r -> r < 0L && (r & 0x01L) == 0x00L;
+            final boolean isHttpClientInitial = initial && isClient.test(typedRef) && isHttp.test(targetName);
+            final boolean isHttpClientReply = !initial && isClient.test(typedRef) && isHttp.test(sourceName);
+            final boolean isHttpServerInitial = initial && isServer.test(typedRef) && isHttp.test(sourceName);
+            final boolean isHttpServerReply = !initial && isServer.test(typedRef) && isHttp.test(targetName);
+            final boolean isHttpProxyInitial = initial && isProxy.test(typedRef) && (isHttp.test(sourceName) || isHttp.test(targetName));
+            final boolean isHttpProxyReply = !initial && isProxy.test(typedRef) && (isHttp.test(sourceName) || isHttp.test(targetName));
 
+            if (isHttpClientInitial || isHttpServerReply || isHttpClientReply || isHttpServerInitial || isHttpProxyInitial | isHttpProxyReply)
+            {
+                HttpBeginExFW httpBeginEx = httpBeginExRO.wrap(extension.buffer(), extension.offset(), extension.limit());
+                httpBeginEx.headers()
+                        .forEach(h -> out.printf("%s: %s\n", h.name().asString(), h.value().asString()));
             }
         }
     }

--- a/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
@@ -121,10 +121,14 @@ public final class LoggableStream implements AutoCloseable
 
         if (verbose && sourceName.startsWith("http"))
         {
-            HttpBeginExFW httpBeginEx = httpBeginExRO.wrap(extension.buffer(), extension.offset(), extension.limit());
+            final long ref = (sourceRef != 0) ? sourceRef : correlationId;
+            if(!((ref % 2 == 0) && sourceName == "http"))
+            {
+                HttpBeginExFW httpBeginEx = httpBeginExRO.wrap(extension.buffer(), extension.offset(), extension.limit());
+                httpBeginEx.headers()
+                    .forEach(h -> out.printf("%s: %s\n", h.name().asString(), h.value().asString()));
+            }
 
-            httpBeginEx.headers()
-                       .forEach(h -> out.printf("%s: %s\n", h.name().asString(), h.value().asString()));
         }
     }
 

--- a/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
@@ -136,10 +136,17 @@ public final class LoggableStream implements AutoCloseable
             final boolean isHttpClientReply = !initial && isClient.test(typedRef) && isHttp.test(sourceName);
             final boolean isHttpServerInitial = initial && isServer.test(typedRef) && isHttp.test(sourceName);
             final boolean isHttpServerReply = !initial && isServer.test(typedRef) && isHttp.test(targetName);
-            final boolean isHttpProxyInitial = initial && isProxy.test(typedRef) && (isHttp.test(sourceName) || isHttp.test(targetName));
-            final boolean isHttpProxyReply = !initial && isProxy.test(typedRef) && (isHttp.test(sourceName) || isHttp.test(targetName));
+            final boolean isHttpProxyInitial = initial && isProxy.test(typedRef) && (isHttp.test(sourceName)
+                    || isHttp.test(targetName));
+            final boolean isHttpProxyReply = !initial && isProxy.test(typedRef) && (isHttp.test(sourceName)
+                    || isHttp.test(targetName));
 
-            if (isHttpClientInitial || isHttpServerReply || isHttpClientReply || isHttpServerInitial || isHttpProxyInitial | isHttpProxyReply)
+            if (isHttpClientInitial
+                    || isHttpServerReply
+                    || isHttpClientReply
+                    || isHttpServerInitial
+                    || isHttpProxyInitial
+                    | isHttpProxyReply)
             {
                 HttpBeginExFW httpBeginEx = httpBeginExRO.wrap(extension.buffer(), extension.offset(), extension.limit());
                 httpBeginEx.headers()

--- a/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
@@ -122,13 +122,13 @@ public final class LoggableStream implements AutoCloseable
         if (verbose && sourceName.startsWith("http"))
         {
             final long ref = (sourceRef != 0) ? sourceRef : correlationId;
-            if(!((ref % 2 == 0) && sourceName == "http"))
+            if(!((ref % 2 == 0) && sourceName.equals("http")) && !((ref % 2 != 0) && sourceName.equals("http2")))
             {
-                HttpBeginExFW httpBeginEx = httpBeginExRO.wrap(extension.buffer(), extension.offset(), extension.limit());
-                httpBeginEx.headers()
-                    .forEach(h -> out.printf("%s: %s\n", h.name().asString(), h.value().asString()));
-            }
+                    HttpBeginExFW httpBeginEx = httpBeginExRO.wrap(extension.buffer(), extension.offset(), extension.limit());
+                    httpBeginEx.headers()
+                            .forEach(h -> out.printf("%s: %s\n", h.name().asString(), h.value().asString()));
 
+            }
         }
     }
 


### PR DESCRIPTION
This is my understanding about the issue please correct me if I am wrong. In the command-log we are trying to print out BeginFrameExFW where it is not actually presented because we don't really need them in the high level nucleus such as TLS and WS.

By l looking into RA command configuration this is stack I captured.

`Client => TCP →  TLC →  HTTP → HTTP-Inject → HTTP-Cache → Auth-jwt → HTTP2 → WS`

` TCP ← TLC ← HTTP ← HTT-Inject ← HTTP-Cache ← Auth-jwt ← HTTP2 ← WS <==Server` 

So we need to make sure that we don't print when `TLC ← HTTP` for server response and `HTTP2 → WS` for client request.


