### PR TITLE
Added flags to DATA frame logging, added separator to counters logging

### DIFF
--- a/src/main/java/org/reaktivity/command/log/internal/LogCountersCommand.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LogCountersCommand.java
@@ -78,7 +78,7 @@ public final class LogCountersCommand implements Runnable
                 "{" +
                 "\"nukleus\": \"%s\"," +
                 "\"name\": \"%s\"," +
-                "\"value\":%d" +
+                "\"value\":%,d" +
                 "}\n", owner, name, manager.getCounterValue(id)));
     }
 

--- a/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LoggableStream.java
@@ -188,10 +188,11 @@ public final class LoggableStream implements AutoCloseable
         final int length = data.length();
         final int padding = data.padding();
         final long authorization = data.authorization();
+        final byte flags = (byte) (data.flags() & 0xFF);
         final long budget = budgets.computeIfPresent(streamId, (i, b) -> b - (length + padding));
 
         out.printf(format(streamFormat, timestamp, budget, traceId, streamId,
-                          format("DATA [%d] [%d] [0x%016x]", length, padding, authorization)));
+                          format("DATA [%d] [%d] [%x] [0x%016x]", length, padding, flags, authorization)));
     }
 
     private void handleEnd(


### PR DESCRIPTION
Example output (added field in bold):

[806058144056581] [0x00000000] [0x8000000000000067] [kafka -> source]	[0x0000000000000002] DATA [150] [0] **[2]** [0x0000000000000000]
[806058154604446] [0x00000022] [0x800000000000009d] [kafka -> source]	[0x0000000000000002] DATA [116] [0] **[1]** [0x0000000000000000]
[806058154748110] [0x0000008a] [0x800000000000009d] [kafka -> source]	[0x0000000000000002] DATA [12] [0] **[3]** [0x0000000000000000]

The first two represent a frame with INIT flag set and one with FIN flag set. The third has both set.

Example output for counters:

{"nukleus": "kafka","name": "acquires","value":0}
{"nukleus": "kafka","name": "releases","value":0}
{"nukleus": "kafka","name": "cache.inuse","value":1,073,717,248}
{"nukleus": "kafka","name": "message.cache.buffer.acquires","value":4,573,094}
{"nukleus": "kafka","name": "message.cache.buffer.releases","value":4,535,328}
{"nukleus": "kafka","name": "cache.misses","value":49,984}
{"nukleus": "kafka","name": "historical.fetches.tcp.1","value":39,857}
{"nukleus": "kafka","name": "cache.hits","value":107}