### PR TITLE
Make thousands separator optional, defaulting to no separator for backwards compatibility

### DIFF
--- a/src/main/java/org/reaktivity/command/log/internal/LogCommand.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LogCommand.java
@@ -43,7 +43,7 @@ public final class LogCommand
         options.addOption(builder("d").longOpt("directory").hasArg().desc("configuration directory").build());
         options.addOption(builder("v").longOpt("verbose").desc("verbose output").build());
         options.addOption(builder("i").hasArg().longOpt("interval").desc("run command continuously at interval").build());
-        options.addOption(builder("s").longOpt("separator").desc("include thousands separator").build());
+        options.addOption(builder("s").longOpt("separator").desc("include thousands separator in integer values").build());
 
         CommandLine cmdline = parser.parse(options, args);
 

--- a/src/main/java/org/reaktivity/command/log/internal/LogCommand.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LogCommand.java
@@ -43,6 +43,7 @@ public final class LogCommand
         options.addOption(builder("d").longOpt("directory").hasArg().desc("configuration directory").build());
         options.addOption(builder("v").longOpt("verbose").desc("verbose output").build());
         options.addOption(builder("i").hasArg().longOpt("interval").desc("run command continuously at interval").build());
+        options.addOption(builder("s").longOpt("separator").desc("include thousands separator").build());
 
         CommandLine cmdline = parser.parse(options, args);
 
@@ -55,6 +56,7 @@ public final class LogCommand
         {
             String directory = cmdline.getOptionValue("directory");
             boolean verbose = cmdline.hasOption("verbose");
+            boolean separator = cmdline.hasOption("separator");
             String type = cmdline.getOptionValue("type", "streams");
             final int interval = Integer.parseInt(cmdline.getOptionValue("interval", "0"));
 
@@ -71,11 +73,11 @@ public final class LogCommand
             }
             else if ("counters".equals(type))
             {
-                command = new LogCountersCommand(config, System.out::printf, verbose);
+                command = new LogCountersCommand(config, System.out::printf, verbose, separator);
             }
             else if ("queues".equals(type))
             {
-                command = new LogQueueDepthCommand(config, System.out::printf, verbose);
+                command = new LogQueueDepthCommand(config, System.out::printf, verbose, separator);
             }
             else if ("routes".equals(type))
             {

--- a/src/main/java/org/reaktivity/command/log/internal/LogCountersCommand.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LogCountersCommand.java
@@ -30,6 +30,7 @@ public final class LogCountersCommand implements Runnable
 {
     private final Path directory;
     private final boolean verbose;
+    private final boolean separator;
     private final int commandBufferCapacity;
     private final int responseBufferCapacity;
     private final int counterLabelsBufferCapacity;
@@ -40,10 +41,12 @@ public final class LogCountersCommand implements Runnable
     LogCountersCommand(
         Configuration config,
         Logger out,
-        boolean verbose)
+        boolean verbose,
+        boolean separator)
     {
         this.directory = config.directory();
         this.verbose = verbose;
+        this.separator = separator;
         this.commandBufferCapacity = config.commandBufferCapacity();
         this.responseBufferCapacity = config.responseBufferCapacity();
         this.counterLabelsBufferCapacity = config.counterLabelsBufferCapacity();
@@ -74,11 +77,13 @@ public final class LogCountersCommand implements Runnable
     {
         String owner = controlPath.getName(controlPath.getNameCount() - 2).toString();
         CountersManager manager = countersByPath.computeIfAbsent(controlPath, this::newCountersManager);
+        final String valueFormat = separator ? ",d" : "d";
+
         manager.forEach((id, name) -> out.printf(
                 "{" +
                 "\"nukleus\": \"%s\"," +
                 "\"name\": \"%s\"," +
-                "\"value\":%,d" +
+                "\"value\":%" + valueFormat +
                 "}\n", owner, name, manager.getCounterValue(id)));
     }
 

--- a/src/main/java/org/reaktivity/command/log/internal/LogQueueDepthCommand.java
+++ b/src/main/java/org/reaktivity/command/log/internal/LogQueueDepthCommand.java
@@ -31,6 +31,7 @@ public final class LogQueueDepthCommand implements Runnable
 {
     private final Path directory;
     private final boolean verbose;
+    private final boolean separator;
     private final Logger out;
 
     private final long streamsCapacity;
@@ -40,11 +41,13 @@ public final class LogQueueDepthCommand implements Runnable
     public LogQueueDepthCommand(
         Configuration config,
         Logger out,
-        boolean verbose)
+        boolean verbose,
+        boolean separator)
     {
         this.directory = config.directory();
         this.out = out;
         this.verbose = verbose;
+        this.separator = separator;
         this.streamsCapacity = config.streamsBufferCapacity();
         this.throttleCapacity = config.throttleBufferCapacity();
         this.layoutsByPath = new LinkedHashMap<>();
@@ -98,7 +101,9 @@ public final class LogQueueDepthCommand implements Runnable
         long consumerAt = buffer.consumerPosition();
         long producerAt = buffer.producerPosition();
 
-        out.printf("{\"nukleus\":\"%s\", \"source\":\"%s\", \"type\":\"%s\", \"depth\":%d}\n",
+        final String valueFormat = separator ? ",d" : "d";
+
+        out.printf("{\"nukleus\":\"%s\", \"source\":\"%s\", \"type\":\"%s\", \"depth\":%" + valueFormat + "}\n",
                 nukleus, source, type, producerAt - consumerAt);
     }
 


### PR DESCRIPTION
PR #25 included a change to make the counters output more legible by including the thousands separator ("," in most regions) in the output integer counter values.  This was a backward incompatible change which may break downstream systems that are passing the output.

To resolve this issue, this PR  makes the thousand separator optional, defaulting to no separator. This option  affects the output for the `counters` and `queues`  usages. There is no affect on the `streams` and `streams-nowait` usages.

Specifically, it adds a command line option, `-s`, to turn on including a thousands separator in values reported by the counters and queues options. Default is not to include thousands separators, for backwards  compatibility with downstream systems that may be assuming integer values are in valid Java integer format.

The usage printed by `java -jar command-log.jar -help` is now as follows:
```
usage: log
 -d,--directory <arg>   configuration directory
 -h,--help              print this message
 -i,--interval <arg>    run command continuously at interval
 -s,--separator         include thousands separator
 -t,--type <arg>        streams* | streams-nowait | counters | queues |
                        routes
 -v,--verbose           verbose output
```