### PR TITLE
Accommodate Kafka Headers Sequence Filter Condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <nukleus.plugin.version>0.73</nukleus.plugin.version>
     <nukleus.amqp.spec.version>0.23</nukleus.amqp.spec.version>
     <nukleus.mqtt.spec.version>0.46</nukleus.mqtt.spec.version>
-    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>0.159</nukleus.kafka.spec.version>
     <nukleus.http.spec.version>0.97</nukleus.http.spec.version>
     <nukleus.tls.spec.version>0.53</nukleus.tls.spec.version>
     <nukleus.tcp.spec.version>0.63</nukleus.tcp.spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <nukleus.plugin.version>0.73</nukleus.plugin.version>
     <nukleus.amqp.spec.version>0.23</nukleus.amqp.spec.version>
     <nukleus.mqtt.spec.version>0.46</nukleus.mqtt.spec.version>
-    <nukleus.kafka.spec.version>0.157</nukleus.kafka.spec.version>
+    <nukleus.kafka.spec.version>develop-SNAPSHOT</nukleus.kafka.spec.version>
     <nukleus.http.spec.version>0.97</nukleus.http.spec.version>
     <nukleus.tls.spec.version>0.53</nukleus.tls.spec.version>
     <nukleus.tcp.spec.version>0.63</nukleus.tcp.spec.version>


### PR DESCRIPTION
Allow command log to print `KafkaHeadersFW`. Also fixed filters not being printed on merged beginEx.